### PR TITLE
Fix order of initialisation, null check and scanning for source maps

### DIFF
--- a/src/DukConnection.ts
+++ b/src/DukConnection.ts
@@ -37,8 +37,6 @@ export class DukConnection extends EE.EventEmitter
     constructor()
     {
         super();
-
-
     }
 
     //-----------------------------------------------------------

--- a/src/DukDbgProtocol.ts
+++ b/src/DukDbgProtocol.ts
@@ -840,7 +840,7 @@ export class DukDbgProtocol extends EE.EventEmitter
             this.onDisconnected( reason );
         }); 
         
-        if ( remainderBuf.length > 1 )
+        if ( remainderBuf.length > 0 )
             this.onReceiveData(remainderBuf);
     }
 

--- a/src/DukDbgProtocol.ts
+++ b/src/DukDbgProtocol.ts
@@ -808,12 +808,10 @@ export class DukDbgProtocol extends EE.EventEmitter
     private _emmitedDisonnected:boolean = false;
 
     //-----------------------------------------------------------
-    constructor( conn:DukConnection, remainderBuf:Buffer, logger:Function )
+    constructor(logger:Function )
     {
         super();
-
         this.log = ( logger || (() => {}) );
-
         this._inBufSize = 0;
 
         this._outBuf    = new DukMsgBuilder( DukDbgProtocol.OUT_BUF_SIZE );
@@ -822,7 +820,11 @@ export class DukDbgProtocol extends EE.EventEmitter
 
         this._msg        = [];
         this._numDvalues = 0;
-
+    }
+    
+    //-----------------------------------------------------------
+    public connect( conn:DukConnection, remainderBuf:Buffer ): void
+    {   
         this._conn    = conn;
         this._version = conn._protoVersion;
 
@@ -836,10 +838,10 @@ export class DukDbgProtocol extends EE.EventEmitter
 
         this._conn.once( "disconnect", ( reason ) => {
             this.onDisconnected( reason );
-        });
-
-        if( remainderBuf.length > 0 )
-            this.onReceiveData( remainderBuf )
+        }); 
+        
+        if ( remainderBuf.length > 1 )
+            this.onReceiveData(remainderBuf);
     }
 
     //-----------------------------------------------------------

--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -253,7 +253,7 @@ class SourceFile
         {
             let pos = this.srcMap.originalPositionFor( line, 0, Bias.LEAST_UPPER_BOUND );
             
-            if( pos.line != null )
+            if( pos && pos.line != null )
             {
                 return {
                     path     : pos.source,
@@ -449,7 +449,7 @@ export class DukDebugSession extends DebugSession
     //-----------------------------------------------------------
     private initDukDbgProtocol( conn:DukConnection, buf:Buffer) : void
     {
-        this._dukProto = new DukDbgProtocol( conn, buf, ( msg ) => this.dbgLog(msg) ); 
+        this._dukProto = new DukDbgProtocol( ( msg ) => this.dbgLog(msg) ); 
         
         // Status
         this._dukProto.on( DukEvent[DukEvent.nfy_status], ( status:DukStatusNotification ) => {
@@ -527,6 +527,9 @@ export class DukDebugSession extends DebugSession
         this._dukProto.on( DukEvent[DukEvent.nfy_appmsg], ( e:DukAppNotification ) => {
             this.logToClient( e.messages.join(' ') + '\n' );
         });
+        
+        // Connect after callbacks have been attached to finish initialisation
+        this._dukProto.connect(conn, buf);
     }
 
     //-----------------------------------------------------------
@@ -2176,10 +2179,10 @@ export class DukDebugSession extends DebugSession
                     continue;
                 
                 var candidate = this.mapSourceFile( Path.join( rootPath, f ) );
-                if (candidate.name == name)
+                if (candidate.name == Path.join( pathUnderRoot, name ) )
                     return candidate;
                 if (!candidate.srcMap)
-                    return;
+                    continue;
                 for (var candidateFile of candidate.srcMap._sources) {
                     if (candidateFile && Path.resolve(this._outDir, candidateFile) == path)
                         return candidate;


### PR DESCRIPTION
Hi, changed the whitespace settings in my editor :)

This change means that:

* The initial STATUS message is not processed before the callbacks are registered on the protocol object. The debugger failed to connect properly most of the time because the initial handshake wasn't successful.  I've changed the DukDbgProtocol object to have a two phase init, so we can attach the callbacks first and then attach the connection and process the "remainderBuf".
* Sourcemaps are loaded correctly when scanning directories.
* We dont get a null dereference if _smc isn't loaded yet.

I've tested on JS compiled from TS and bundled with browserify (With debugger config sourceMaps = true), and also on Javascript written in raw ES5 (With debugger config sourceMaps = false).

Thanks.