### PR TITLE
Set variable

### DIFF
--- a/src/DukConnection.ts
+++ b/src/DukConnection.ts
@@ -37,8 +37,6 @@ export class DukConnection extends EE.EventEmitter
     constructor()
     {
         super();
-
-
     }
 
     //-----------------------------------------------------------

--- a/src/DukDbgProtocol.ts
+++ b/src/DukDbgProtocol.ts
@@ -808,12 +808,10 @@ export class DukDbgProtocol extends EE.EventEmitter
     private _emmitedDisonnected:boolean = false;
 
     //-----------------------------------------------------------
-    constructor( conn:DukConnection, remainderBuf:Buffer, logger:Function )
+    constructor(logger:Function )
     {
         super();
-
         this.log = ( logger || (() => {}) );
-
         this._inBufSize = 0;
 
         this._outBuf    = new DukMsgBuilder( DukDbgProtocol.OUT_BUF_SIZE );
@@ -822,7 +820,11 @@ export class DukDbgProtocol extends EE.EventEmitter
 
         this._msg        = [];
         this._numDvalues = 0;
-
+    }
+    
+    //-----------------------------------------------------------
+    public connect( conn:DukConnection, remainderBuf:Buffer ): void
+    {   
         this._conn    = conn;
         this._version = conn._protoVersion;
 
@@ -836,10 +838,10 @@ export class DukDbgProtocol extends EE.EventEmitter
 
         this._conn.once( "disconnect", ( reason ) => {
             this.onDisconnected( reason );
-        });
-
-        if( remainderBuf.length > 0 )
-            this.onReceiveData( remainderBuf )
+        }); 
+        
+        if ( remainderBuf.length > 1 )
+            this.onReceiveData(remainderBuf);
     }
 
     //-----------------------------------------------------------

--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -1319,16 +1319,38 @@ export class DukDebugSession extends DebugSession
         this.dbgLog( "[FE] setVariableRequest" );
         
         var properties = this._dbgState.varHandles.get( args.variablesReference );
-        var stackFrame = properties.scope.stackFrame;
+        if( !properties )
+        {
+            this.requestFailedResponse( response, "Failed to find variable: " + args.variablesReference );
+            return;
+        }
+        var frame = properties.scope.stackFrame;
         let variableName = this.getVariableName(args.name, properties);
         let expression = variableName + " = " + args.value;
         
-        this._dukProto.requestEval( expression, stackFrame.depth );
-        response.body = {
-            value: args.value
-        };
-        
-        this.sendResponse( response );
+        this._dukProto.requestEval( expression, frame.depth )
+        .then( resp => {       
+            let r = <DukEvalResponse>resp;
+            if( !r.success )
+            {
+                this.requestFailedResponse( response, "Eval failed: " + r.result );    
+                return;
+            }
+            else
+            {
+                this.resolveObject(expression, r.result, frame.scopes[0]).then(
+                    (v) => 
+                {
+                    response.body = {
+                        value: v.value,
+                        variablesReference: v.variablesReference
+                    };
+                    this.sendResponse( response );    
+                })
+            }   
+        }).catch( err =>{
+            this.requestFailedResponse( response, "Eval request failed: " + err );
+        });
     }
     
     //-----------------------------------------------------------

--- a/src/DukDebugger.ts
+++ b/src/DukDebugger.ts
@@ -253,7 +253,7 @@ class SourceFile
         {
             let pos = this.srcMap.originalPositionFor( line, 0, Bias.LEAST_UPPER_BOUND );
             
-            if( pos.line != null )
+            if( pos && pos.line != null )
             {
                 return {
                     path     : pos.source,
@@ -449,7 +449,7 @@ export class DukDebugSession extends DebugSession
     //-----------------------------------------------------------
     private initDukDbgProtocol( conn:DukConnection, buf:Buffer) : void
     {
-        this._dukProto = new DukDbgProtocol( conn, buf, ( msg ) => this.dbgLog(msg) ); 
+        this._dukProto = new DukDbgProtocol( ( msg ) => this.dbgLog(msg) ); 
         
         // Status
         this._dukProto.on( DukEvent[DukEvent.nfy_status], ( status:DukStatusNotification ) => {
@@ -527,6 +527,9 @@ export class DukDebugSession extends DebugSession
         this._dukProto.on( DukEvent[DukEvent.nfy_appmsg], ( e:DukAppNotification ) => {
             this.logToClient( e.messages.join(' ') + '\n' );
         });
+        
+        // Connect after callbacks have been attached to finish initialisation
+        this._dukProto.connect(conn, buf);
     }
 
     //-----------------------------------------------------------
@@ -2176,10 +2179,10 @@ export class DukDebugSession extends DebugSession
                     continue;
                 
                 var candidate = this.mapSourceFile( Path.join( rootPath, f ) );
-                if (candidate.name == name)
+                if (candidate.name == Path.join( pathUnderRoot, name ) )
                     return candidate;
                 if (!candidate.srcMap)
-                    return;
+                    continue;
                 for (var candidateFile of candidate.srcMap._sources) {
                     if (candidateFile && Path.resolve(this._outDir, candidateFile) == path)
                         return candidate;


### PR DESCRIPTION
Adds a very basic implementation of setVariable.  Basically add a parent to the var properties object, and recursively scan upwards from the variable to get a string that we can evaluate.

e.g. if I set this.object.colour.red to 255 in the UI

the function receives "red" along with an id, which we use to scan upwards through variable properties to generate an array:

["this", "object", "colour", "red"]

then join(".") to eventually make a string

"this.object.colour.red = 255" which we can evaluate.

This PR also contains the other changes from #2 so it may be easier to have a look at that one first.